### PR TITLE
added-new-commands: v1.3.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Movie and TV show tracker plugin for Obsidian
 
 ![Add new](https://raw.githubusercontent.com/Shreshth-mehra/Obsidian-TV-Tracker/main/Showcase/addnew2.gif)
 
+# New in v1.3.16
+-  Added an Direct Obsidian Command for adding new titles. This will allow you to add new titles from anywhere in Obsidian. You can also assign a hotkey to this command for even faster access.
+- Added the command for this which are previously available in the settings. Will work on currently opened file.
+
+### These are commands that are available in the command palette
+- **Movie and TV show tracker: Search and add movie/TV show** - to library (User can select the item after that they can add the satus and rating)
+- **Movie and TV show tracker: Add episode list for current file** -  (Also fetch the New Season if Available & New Episodes as well)
+- **Movie and TV show tracker: Update current file with new data**
+- **Movie and TV show tracker: Update Episode tracking for current file**
+- **Movie and TV show tracker: Update Streaming availability for current file**
+
 # New in v1.3.15
 Small bug fix
 - Removed the double quotes from the Available on Property.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "tv-tracker",
 	"name": "Movie and TV show tracker",
-	"version": "1.3.15",
+	"version": "1.3.16",
 	"minAppVersion": "0.15.0",
 	"description": "A Movie and TV show tracker.",
 	"author": "Shreshth Mehra",


### PR DESCRIPTION
-  Added an Direct Obsidian Command for adding new titles. This will allow you to add new titles from anywhere in Obsidian. You can also assign a hotkey to this command for even faster access.
- Added the command for this which are previously available in the settings. Will work on currently opened file.

### These are commands that are available in the command palette
- **Movie and TV show tracker: Search and add movie/TV show** - to library (User can select the item after that they can add the satus and rating)
- **Movie and TV show tracker: Add episode list for current file** -  (Also fetch the New Season if Available & New Episodes as well)
- **Movie and TV show tracker: Update current file with new data**
- **Movie and TV show tracker: Update Episode tracking for current file**
- **Movie and TV show tracker: Update Streaming availability for current file**

### ! Important: Only Merge if this didn't break any other functionality

![image](https://github.com/user-attachments/assets/f7976826-de92-403a-8371-590c312f16fb)

![image](https://github.com/user-attachments/assets/9a4a5938-94f4-46f7-a417-7c704acb67a0)

![image](https://github.com/user-attachments/assets/3256d458-4c35-4687-a76a-69ecd811faf0)
